### PR TITLE
fix: Build failure due to not interpreting env vars for mock/real data switch

### DIFF
--- a/src/app/alpaca/[id]/page.js
+++ b/src/app/alpaca/[id]/page.js
@@ -1,4 +1,4 @@
-import { db } from "@/functions/db.js";
+import db from "@/functions/db.js";
 import { AlpacaDetail } from "@/components/alpacaDetail.js";
 import { Suspense } from "react";
 import { generateImageSource } from "@/functions/generateImageSource";

--- a/src/app/api/animal/[id]/route.js
+++ b/src/app/api/animal/[id]/route.js
@@ -1,4 +1,4 @@
-import { db } from "@/functions/db.js";
+import db from "@/functions/db.js";
 
 export async function GET(req, context) {
   const { id } = await context?.params;

--- a/src/app/api/animals/search/route.js
+++ b/src/app/api/animals/search/route.js
@@ -1,4 +1,4 @@
-import { db } from "@/functions/db.js";
+import db from "@/functions/db.js";
 
 export async function POST(request) {
   try {

--- a/src/app/api/companies/[lat]/[lng]/[radius]/route.js
+++ b/src/app/api/companies/[lat]/[lng]/[radius]/route.js
@@ -1,4 +1,4 @@
-import { db } from "@/functions/db.js";
+import db from "@/functions/db.js";
 
 export async function GET(req, context) {
   const searchParams = new URLSearchParams(req.url);

--- a/src/app/api/companies/route.js
+++ b/src/app/api/companies/route.js
@@ -1,4 +1,9 @@
-import { db } from "@/functions/db.js";
+import db from "@/functions/db.js";
+
+// Due to not passing in a parameter to the GET() method,
+// nextjs thinks this can be a static page upon build.
+// Therefore forcing it do be dynamic.
+export const dynamic = "force-dynamic";
 
 export async function GET() {
   try {

--- a/src/app/api/companies/search/route.js
+++ b/src/app/api/companies/search/route.js
@@ -1,4 +1,4 @@
-import { db } from "@/functions/db.js";
+import db from "@/functions/db.js";
 
 export async function POST(request) {
   try {

--- a/src/app/api/company/[id]/route.js
+++ b/src/app/api/company/[id]/route.js
@@ -1,4 +1,4 @@
-import { db } from "@/functions/db.js";
+import db from "@/functions/db.js";
 
 export async function GET(req, context) {
   const { id } = await context?.params;

--- a/src/app/api/locations/search/route.js
+++ b/src/app/api/locations/search/route.js
@@ -1,4 +1,4 @@
-import { db } from "@/functions/db.js";
+import db from "@/functions/db.js";
 
 export async function POST(request) {
   try {

--- a/src/app/farm/[id]/page.js
+++ b/src/app/farm/[id]/page.js
@@ -1,4 +1,4 @@
-import { db } from "@/functions/db.js";
+import db from "@/functions/db.js";
 import { AlpacasDetail } from "@/components/alpacasDetail.js";
 import { Suspense } from "react";
 

--- a/src/functions/database.elastic.js
+++ b/src/functions/database.elastic.js
@@ -30,35 +30,41 @@ export async function getAnimal(id) {
 }
 
 export async function getAnimals(query) {
+  const db = connectToDatabase();
   const fetcher = new AnimalsFetcher(db, query);
 
   return await fetcher.fetch();
 }
 
 export async function getCompany(id) {
+  const db = connectToDatabase();
   const fetcher = new CompanyFetcher(db, id);
   return await fetcher.fetch();
 }
 
 export async function getCompanies(query) {
+  const db = connectToDatabase();
   const fetcher = new CompaniesFetcher(db, query);
 
   return await fetcher.fetch();
 }
 
 export async function getFarms() {
+  const db = connectToDatabase();
   const fetcher = new FarmsFetcher(db);
 
   return await fetcher.fetch();
 }
 
 export async function getLocations(query) {
+  const db = connectToDatabase();
   const fetcher = new LocationsFetcher(db, query);
 
   return await fetcher.fetch();
 }
 
 export async function getGeoDistanceRadius(lat, lng, radius, publicFarms, privateFarms) {
+  const db = connectToDatabase();
   const fetcher = new GeoDistanceRadiusFetcher(db, lat, lng, radius, publicFarms, privateFarms);
 
   return await fetcher.fetch();

--- a/src/functions/database.elastic.js
+++ b/src/functions/database.elastic.js
@@ -7,9 +7,11 @@ import FarmsFetcher from "@/functions/farmsFetcher.js";
 import GeoDistanceRadiusFetcher from "@/functions/geoDistanceRadiusFetcher.js";
 import LocationsFetcher from "@/functions/locationsFetcher.js";
 
-export default class Database {
-  constructor() {
-    this.elastic = new Client({
+let elastic = null;
+
+const connectToDatabase = () => {
+  if (!elastic) {
+    elastic = new Client({
       cloud: {
         id: process.env.ELASTIC_CLOUD_ID,
       },
@@ -18,44 +20,46 @@ export default class Database {
       },
     });
   }
+  return elastic;
+};
 
-  async getAnimal(id) {
-    const fetcher = new AnimalFetcher(this.elastic, id);
-    return await fetcher.fetch();
-  }
+export async function getAnimal(id) {
+  const db = connectToDatabase();
+  const fetcher = new AnimalFetcher(db, id);
+  return await fetcher.fetch();
+}
 
-  async getAnimals(query) {
-    const fetcher = new AnimalsFetcher(this.elastic, query);
+export async function getAnimals(query) {
+  const fetcher = new AnimalsFetcher(db, query);
 
-    return await fetcher.fetch();
-  }
+  return await fetcher.fetch();
+}
 
-  async getCompany(id) {
-    const fetcher = new CompanyFetcher(this.elastic, id);
-    return await fetcher.fetch();
-  }
+export async function getCompany(id) {
+  const fetcher = new CompanyFetcher(db, id);
+  return await fetcher.fetch();
+}
 
-  async getCompanies(query) {
-    const fetcher = new CompaniesFetcher(this.elastic, query);
+export async function getCompanies(query) {
+  const fetcher = new CompaniesFetcher(db, query);
 
-    return await fetcher.fetch();
-  }
+  return await fetcher.fetch();
+}
 
-  async getFarms() {
-    const fetcher = new FarmsFetcher(this.elastic);
+export async function getFarms() {
+  const fetcher = new FarmsFetcher(db);
 
-    return await fetcher.fetch();
-  }
+  return await fetcher.fetch();
+}
 
-  async getLocations(query) {
-    const fetcher = new LocationsFetcher(this.elastic, query);
+export async function getLocations(query) {
+  const fetcher = new LocationsFetcher(db, query);
 
-    return await fetcher.fetch();
-  }
+  return await fetcher.fetch();
+}
 
-  async getGeoDistanceRadius(lat, lng, radius, publicFarms, privateFarms) {
-    const fetcher = new GeoDistanceRadiusFetcher(this.elastic, lat, lng, radius, publicFarms, privateFarms);
+export async function getGeoDistanceRadius(lat, lng, radius, publicFarms, privateFarms) {
+  const fetcher = new GeoDistanceRadiusFetcher(db, lat, lng, radius, publicFarms, privateFarms);
 
-    return await fetcher.fetch();
-  }
+  return await fetcher.fetch();
 }

--- a/src/functions/database.mock.js
+++ b/src/functions/database.mock.js
@@ -11,45 +11,44 @@ export const fileReader = (fileIn) => {
   }
 };
 
-export default class MockDatabase {
-  async getAnimal(id) {
-    return id == 2773 ? await fileReader("animal_2773.json") : [];
-  }
-  async getAnimals(query) {
-    const result = [];
+export async function getAnimal(id) {
+  return id == 2773 ? await fileReader("animal_2773.json") : [];
+}
 
-    if (query == "lund") {
-      return fileReader("animals_lund.json");
-    }
+export async function getAnimals(query) {
+  const result = [];
 
-    if (query == "trygv") {
-      return fileReader("animals_trygv.json");
-    }
-
-    return result;
+  if (query == "lund") {
+    return fileReader("animals_lund.json");
   }
 
-  async getCompany(id) {
-    return id === "61" ? await fileReader("company_61.json") : [];
+  if (query == "trygv") {
+    return fileReader("animals_trygv.json");
   }
 
-  async getCompanies(query) {
-    return query == "lund" ? fileReader("companies_lund.json") : [];
-  }
+  return result;
+}
 
-  async getFarms() {
-    return await fileReader("farms_mock.json");
-  }
+export async function getCompany(id) {
+  return id === "61" ? await fileReader("company_61.json") : [];
+}
 
-  async getGeoDistanceRadius(lat, lng, radius, publicFarms, privateFarms) {
-    // Response is mock of searching "Kyrksæterøra, Norway" in location search bar (Google autocomplete)
-    // then sending this request with found lat,lng:
-    // http://localhost:3000/api/companies/63.292781/9.0826007/500000
+export async function getCompanies(query) {
+  return query == "lund" ? fileReader("companies_lund.json") : [];
+}
 
-    return fileReader("api_farms_radius_respose_Kyrksæterøra.json");
-  }
+export async function getFarms() {
+  return await fileReader("farms_mock.json");
+}
 
-  async getLocations(query) {
-    return query == "lund" ? fileReader("locations_lund.json") : [];
-  }
+export async function getGeoDistanceRadius(lat, lng, radius, publicFarms, privateFarms) {
+  // Response is mock of searching "Kyrksæterøra, Norway" in location search bar (Google autocomplete)
+  // then sending this request with found lat,lng:
+  // http://localhost:3000/api/companies/63.292781/9.0826007/500000
+
+  return fileReader("api_farms_radius_respose_Kyrksæterøra.json");
+}
+
+export async function getLocations(query) {
+  return query == "lund" ? fileReader("locations_lund.json") : [];
 }

--- a/src/functions/db.js
+++ b/src/functions/db.js
@@ -1,4 +1,3 @@
-import Elastic from "@/functions/database.elastic.js";
-import Mock from "@/functions/database.mock.js";
-
-export const db = process.env.NODE_ENV === "test" ? new Mock() : new Elastic();
+export default process?.env?.NODE_ENV === "test"
+  ? await import("@/functions/database.mock.js")
+  : await import("@/functions/database.elastic.js");


### PR DESCRIPTION
Peer programmed

**Fixes**
- GCP cloud build failed due to not interpreting the env vars.  In fact any build without .env vars available failed which resulted in logic to use mock functions did not work, for example in test mode

**Updates**

- Convert db classes to pure functions which turns the database classes into pure functions making it more suitable for next to detect what should be static pages and not

-  /api/companies/route.js set to force the route to be dynamic. The route does not take any params so Next.js thinks it is something it can treat as static even if it is not

- Import real/mock functions depending on env



