### PR TITLE
feat: Get animals, companies, farms returns total as part of result

### DIFF
--- a/src/app/api/animals/search/route.test.js
+++ b/src/app/api/animals/search/route.test.js
@@ -26,28 +26,28 @@ describe(`POST /api/animals/search { query: "trygv" }`, () => {
   });
 
   test(`At least 1 item`, async () => {
-    const actual = data.length;
+    const actual = data.total;
     const expected = 1;
 
     assert.isAtLeast(actual, expected, `Number of items returned: ${actual} - should return at least ${expected}`);
   });
 
   test(`Value of data[0].alpacaId`, async () => {
-    const actual = data[0].alpacaId;
+    const actual = data.items[0].alpacaId;
     const expected = 2773;
 
     assert.equal(actual, expected, `Item ${actual} - should return ${expected}`);
   });
 
   test(`Value of  data[0].alpacaRegisteredName[0]`, async () => {
-    const actual = data[0].alpacaRegisteredName[0];
+    const actual = data.items[0].alpacaRegisteredName[0];
     const expected = "ALPAKKAHAGEN SØRUMS <em>TRYGVE</em>";
 
     assert.equal(actual, expected, `Item ${actual} - should return ${expected}`);
   });
 
   test(`Value of  data[0].alpacaShortName[0]`, async () => {
-    const actual = data[0].alpacaShortName[0];
+    const actual = data.items[0].alpacaShortName[0];
     const expected = "<em>TRYGVE</em>";
 
     assert.equal(actual, expected, `Item ${actual} - should return ${expected}`);

--- a/src/app/api/companies/route.test.js
+++ b/src/app/api/companies/route.test.js
@@ -19,7 +19,7 @@ describe("GET /api/companies", () => {
   });
 
   test("At least 2 items", async () => {
-    const actual = data.length;
+    const actual = data.total;
     const expected = 2;
 
     assert.isAtLeast(actual, expected, `Number of items returned: ${actual} - should return at least ${expected}`);

--- a/src/data/animals_lund.json
+++ b/src/data/animals_lund.json
@@ -1,38 +1,41 @@
-[
-  {
-    "alpacaId": 2277,
-    "alpacaRegisteredName": ["<em>LUNA</em>"],
-    "alpacaShortName": ["<em>LUNA</em>"],
-    "companyId": 39
-  },
-  {
-    "alpacaId": 3881,
-    "alpacaRegisteredName": ["KYSTALPAKKA <em>LUNA</em>"],
-    "alpacaShortName": ["<em>LUNA</em>"],
-    "companyId": 151
-  },
-  {
-    "alpacaId": 4238,
-    "alpacaRegisteredName": ["SØRFLAENS <em>LUNA</em>"],
-    "alpacaShortName": ["<em>LUNA</em>"],
-    "companyId": 76
-  },
-  {
-    "alpacaId": 2523,
-    "alpacaRegisteredName": ["TIKOS <em>LUNA</em>"],
-    "alpacaShortName": ["TIKOS <em>LUNA</em>"],
-    "companyId": 88
-  },
-  {
-    "alpacaId": 2618,
-    "alpacaRegisteredName": ["BR.S <em>LUNA</em>"],
-    "alpacaShortName": ["BR.S <em>LUNA</em>"],
-    "companyId": 134
-  },
-  {
-    "alpacaId": 2520,
-    "alpacaRegisteredName": ["ALPACAJOY LA <em>LUNA</em>"],
-    "alpacaShortName": ["LA <em>LUNA</em>"],
-    "companyId": 40
-  }
-]
+{
+  "total": 6,
+  "items": [
+    {
+      "alpacaId": 2277,
+      "alpacaRegisteredName": ["<em>LUNA</em>"],
+      "alpacaShortName": ["<em>LUNA</em>"],
+      "companyId": 39
+    },
+    {
+      "alpacaId": 3881,
+      "alpacaRegisteredName": ["KYSTALPAKKA <em>LUNA</em>"],
+      "alpacaShortName": ["<em>LUNA</em>"],
+      "companyId": 229
+    },
+    {
+      "alpacaId": 4238,
+      "alpacaRegisteredName": ["SØRFLAENS <em>LUNA</em>"],
+      "alpacaShortName": ["<em>LUNA</em>"],
+      "companyId": 76
+    },
+    {
+      "alpacaId": 2523,
+      "alpacaRegisteredName": ["TIKOS <em>LUNA</em>"],
+      "alpacaShortName": ["TIKOS <em>LUNA</em>"],
+      "companyId": 88
+    },
+    {
+      "alpacaId": 2618,
+      "alpacaRegisteredName": ["BR.S <em>LUNA</em>"],
+      "alpacaShortName": ["BR.S <em>LUNA</em>"],
+      "companyId": 134
+    },
+    {
+      "alpacaId": 2520,
+      "alpacaRegisteredName": ["ALPACAJOY LA <em>LUNA</em>"],
+      "alpacaShortName": ["LA <em>LUNA</em>"],
+      "companyId": 40
+    }
+  ]
+}

--- a/src/data/animals_trygv.json
+++ b/src/data/animals_trygv.json
@@ -1,14 +1,17 @@
-[
-  {
-    "alpacaId": 2773,
-    "alpacaRegisteredName": ["ALPAKKAHAGEN SØRUMS <em>TRYGVE</em>"],
-    "alpacaShortName": ["<em>TRYGVE</em>"],
-    "companyId": 61
-  },
-  {
-    "alpacaId": 4185,
-    "alpacaRegisteredName": ["LUNDEGÅRDS <em>TRYGVE</em>"],
-    "alpacaShortName": ["<em>TRYGVE</em>"],
-    "companyId": 28
-  }
-]
+{
+  "total": 2,
+  "items": [
+    {
+      "alpacaId": 2773,
+      "alpacaRegisteredName": ["ALPAKKAHAGEN SØRUMS <em>TRYGVE</em>"],
+      "alpacaShortName": ["<em>TRYGVE</em>"],
+      "companyId": 61
+    },
+    {
+      "alpacaId": 4185,
+      "alpacaRegisteredName": ["LUNDEGÅRDS <em>TRYGVE</em>"],
+      "alpacaShortName": ["<em>TRYGVE</em>"],
+      "companyId": 28
+    }
+  ]
+}

--- a/src/data/farms_mock.json
+++ b/src/data/farms_mock.json
@@ -1,201 +1,204 @@
-[
-  {
-    "id": 1,
-    "count": {
-      "alpacas": {
-        "status": {
-          "active": 108,
-          "dead": 2,
-          "export": 0
-        },
-        "total": 110
-      }
+{
+  "total": 7,
+  "items": [
+    {
+      "id": 1,
+      "count": {
+        "alpacas": {
+          "status": {
+            "active": 108,
+            "dead": 2,
+            "export": 0
+          },
+          "total": 110
+        }
+      },
+      "city": "Oslo",
+      "lat": 59.9139,
+      "lng": 10.7522,
+      "location": {
+        "type": "Point",
+        "coordinates": [10.7522, 59.9139],
+        "google": {
+          "formatted_address": "My Oslo street 4321, 0123 Oslo, Norway",
+          "place_id": "something_1",
+          "directions_url_href": "https://www.google.com/maps/dir/?api=1&origin=&destination=My%20Oslo%20Street%204321,%200123%20Oslo,%20Norway"
+        }
+      },
+      "name": "Oslo Imaginary Farm",
+      "public": true,
+      "private": false,
+      "url": {
+        "original": "http://www.oslofarm.no/",
+        "domain": "www.oslofarm.no",
+        "full": "http://www.oslofarm.no",
+        "path": "/",
+        "pretty": "www.oslofarm.no",
+        "scheme": "http"
+      },
+      "webpage": "http://www.oslofarm.no/"
     },
-    "city": "Oslo",
-    "lat": 59.9139,
-    "lng": 10.7522,
-    "location": {
-      "type": "Point",
-      "coordinates": [10.7522, 59.9139],
-      "google": {
-        "formatted_address": "My Oslo street 4321, 0123 Oslo, Norway",
-        "place_id": "something_1",
-        "directions_url_href": "https://www.google.com/maps/dir/?api=1&origin=&destination=My%20Oslo%20Street%204321,%200123%20Oslo,%20Norway"
-      }
+    {
+      "id": 2,
+      "count": {
+        "alpacas": {
+          "status": {
+            "active": 8,
+            "dead": 1,
+            "export": 0
+          },
+          "total": 9
+        }
+      },
+      "city": "Trondheim",
+      "lat": 63.4305,
+      "lng": 10.3951,
+      "location": {
+        "type": "Point",
+        "coordinates": [10.3951, 63.4305],
+        "google": {
+          "formatted_address": "My Trondheim street 4321, 0123 Trondheim, Norway",
+          "place_id": "something_2"
+        }
+      },
+      "name": "Trondheim Imaginary Farm",
+      "public": true,
+      "private": false
     },
-    "name": "Oslo Imaginary Farm",
-    "public": true,
-    "private": false,
-    "url": {
-      "original": "http://www.oslofarm.no/",
-      "domain": "www.oslofarm.no",
-      "full": "http://www.oslofarm.no",
-      "path": "/",
-      "pretty": "www.oslofarm.no",
-      "scheme": "http"
+    {
+      "id": 3,
+      "count": {
+        "alpacas": {
+          "status": {
+            "active": 20,
+            "dead": 2,
+            "export": 0
+          },
+          "total": 22
+        }
+      },
+      "city": "Tromsø",
+      "lat": 69.6492,
+      "lng": 18.9553,
+      "location": {
+        "type": "Point",
+        "coordinates": [18.9553, 69.6492],
+        "google": {
+          "formatted_address": "My Tromsø street 4321, 0123 Tromsø, Norway",
+          "place_id": "something_3"
+        }
+      },
+      "name": "Tromsø Imaginary Farm",
+      "public": true,
+      "private": false
     },
-    "webpage": "http://www.oslofarm.no/"
-  },
-  {
-    "id": 2,
-    "count": {
-      "alpacas": {
-        "status": {
-          "active": 8,
-          "dead": 1,
-          "export": 0
-        },
-        "total": 9
-      }
+    {
+      "id": 4,
+      "count": {
+        "alpacas": {
+          "status": {
+            "active": 13,
+            "dead": 1,
+            "export": 0
+          },
+          "total": 14
+        }
+      },
+      "city": "Stavanger",
+      "lat": 58.97,
+      "lng": 5.7331,
+      "location": {
+        "type": "Point",
+        "coordinates": [5.7331, 58.97],
+        "google": {
+          "formatted_address": "My Stavanger street 4321, 0123 Stavanger, Norway",
+          "place_id": "something_4"
+        }
+      },
+      "name": "Stavanger Imaginary Farm",
+      "public": true,
+      "private": false
     },
-    "city": "Trondheim",
-    "lat": 63.4305,
-    "lng": 10.3951,
-    "location": {
-      "type": "Point",
-      "coordinates": [10.3951, 63.4305],
-      "google": {
-        "formatted_address": "My Trondheim street 4321, 0123 Trondheim, Norway",
-        "place_id": "something_2"
-      }
+    {
+      "id": 5,
+      "count": {
+        "alpacas": {
+          "status": {
+            "active": 29,
+            "dead": 2,
+            "export": 2
+          },
+          "total": 33
+        }
+      },
+      "city": "Skarsvåg",
+      "lat": 71.1132,
+      "lng": 25.827,
+      "location": {
+        "type": "Point",
+        "coordinates": [25.827, 71.1132],
+        "google": {
+          "formatted_address": "My Skarsvåg street 4321, 0123 Skarsvåg, Norway",
+          "place_id": "something_5"
+        }
+      },
+      "name": "Skarsvåg Imaginary Farm",
+      "public": false,
+      "private": true
     },
-    "name": "Trondheim Imaginary Farm",
-    "public": true,
-    "private": false
-  },
-  {
-    "id": 3,
-    "count": {
-      "alpacas": {
-        "status": {
-          "active": 20,
-          "dead": 2,
-          "export": 0
-        },
-        "total": 22
-      }
+    {
+      "id": 6,
+      "count": {
+        "alpacas": {
+          "status": {
+            "active": 42,
+            "dead": 9,
+            "export": 1
+          },
+          "total": 52
+        }
+      },
+      "city": "Kristiansand",
+      "lat": 58.152951,
+      "lng": 7.9490892,
+      "location": {
+        "type": "Point",
+        "coordinates": [7.9490892, 58.152951],
+        "google": {
+          "formatted_address": "My Kristiansand street 4321, 0123 Kristiansand, Norway",
+          "place_id": "something_6"
+        }
+      },
+      "name": "Kristiansand Imaginary Farm",
+      "public": false,
+      "private": true
     },
-    "city": "Tromsø",
-    "lat": 69.6492,
-    "lng": 18.9553,
-    "location": {
-      "type": "Point",
-      "coordinates": [18.9553, 69.6492],
-      "google": {
-        "formatted_address": "My Tromsø street 4321, 0123 Tromsø, Norway",
-        "place_id": "something_3"
-      }
-    },
-    "name": "Tromsø Imaginary Farm",
-    "public": true,
-    "private": false
-  },
-  {
-    "id": 4,
-    "count": {
-      "alpacas": {
-        "status": {
-          "active": 13,
-          "dead": 1,
-          "export": 0
-        },
-        "total": 14
-      }
-    },
-    "city": "Stavanger",
-    "lat": 58.97,
-    "lng": 5.7331,
-    "location": {
-      "type": "Point",
-      "coordinates": [5.7331, 58.97],
-      "google": {
-        "formatted_address": "My Stavanger street 4321, 0123 Stavanger, Norway",
-        "place_id": "something_4"
-      }
-    },
-    "name": "Stavanger Imaginary Farm",
-    "public": true,
-    "private": false
-  },
-  {
-    "id": 5,
-    "count": {
-      "alpacas": {
-        "status": {
-          "active": 29,
-          "dead": 2,
-          "export": 2
-        },
-        "total": 33
-      }
-    },
-    "city": "Skarsvåg",
-    "lat": 71.1132,
-    "lng": 25.827,
-    "location": {
-      "type": "Point",
-      "coordinates": [25.827, 71.1132],
-      "google": {
-        "formatted_address": "My Skarsvåg street 4321, 0123 Skarsvåg, Norway",
-        "place_id": "something_5"
-      }
-    },
-    "name": "Skarsvåg Imaginary Farm",
-    "public": false,
-    "private": true
-  },
-  {
-    "id": 6,
-    "count": {
-      "alpacas": {
-        "status": {
-          "active": 42,
-          "dead": 9,
-          "export": 1
-        },
-        "total": 52
-      }
-    },
-    "city": "Kristiansand",
-    "lat": 58.152951,
-    "lng": 7.9490892,
-    "location": {
-      "type": "Point",
-      "coordinates": [7.9490892, 58.152951],
-      "google": {
-        "formatted_address": "My Kristiansand street 4321, 0123 Kristiansand, Norway",
-        "place_id": "something_6"
-      }
-    },
-    "name": "Kristiansand Imaginary Farm",
-    "public": false,
-    "private": true
-  },
-  {
-    "id": 120,
-    "city": "KYRKSÆTERØRA",
-    "count": {
-      "alpacas": {
-        "status": {
-          "active": 20,
-          "dead": 0,
-          "export": 0
-        },
-        "total": 20
-      }
-    },
-    "lat": 63.3687244,
-    "lng": 9.145974400000002,
-    "location": {
-      "type": "Point",
-      "coordinates": [9.145974400000002, 63.3687244],
-      "google": {
-        "formatted_address": "My Kyrksæterøra street 4321, 0123 Kyrksæterøra, Norway",
-        "place_id": "something_6"
-      }
-    },
-    "public": true,
-    "private": false,
-    "name": "Oddan Alpakka"
-  }
-]
+    {
+      "id": 120,
+      "city": "KYRKSÆTERØRA",
+      "count": {
+        "alpacas": {
+          "status": {
+            "active": 20,
+            "dead": 0,
+            "export": 0
+          },
+          "total": 20
+        }
+      },
+      "lat": 63.3687244,
+      "lng": 9.145974400000002,
+      "location": {
+        "type": "Point",
+        "coordinates": [9.145974400000002, 63.3687244],
+        "google": {
+          "formatted_address": "My Kyrksæterøra street 4321, 0123 Kyrksæterøra, Norway",
+          "place_id": "something_6"
+        }
+      },
+      "public": true,
+      "private": false,
+      "name": "Oddan Alpakka"
+    }
+  ]
+}

--- a/src/functions/animalsFetcher.js
+++ b/src/functions/animalsFetcher.js
@@ -57,7 +57,7 @@ export default class AnimalsFetcher {
     const total = result.hits.total.value <= this.maxTotal ? result.hits.total.value : this.maxTotal;
 
     if (total === 0) {
-      resolve([]);
+      resolve({ total: 0, items: [] });
       return;
     }
 
@@ -79,7 +79,7 @@ export default class AnimalsFetcher {
       return;
     }
 
-    resolve(this.data); // Callback
+    resolve({ total: total, items: this.data }); // Callback
   }
 
   fetch() {

--- a/src/functions/companiesFetcher.js
+++ b/src/functions/companiesFetcher.js
@@ -52,7 +52,7 @@ export default class CompaniesFetcher {
     const total = result.hits.total.value <= this.maxTotal ? result.hits.total.value : this.maxTotal;
 
     if (total === 0) {
-      resolve([]);
+      resolve({ total: 0, items: [] });
       return;
     }
 
@@ -74,7 +74,7 @@ export default class CompaniesFetcher {
       return;
     }
 
-    resolve(this.data); // Callback
+    resolve({ total: total, items: this.data }); // Callback
   }
 
   fetch() {

--- a/src/functions/database.mock.js
+++ b/src/functions/database.mock.js
@@ -16,14 +16,22 @@ export const getAnimal = (id) => {
 };
 
 export const getAnimals = (query) => {
-  const result = [];
+  let total = 0;
+  let items = [];
+  let result = { total: total, items: items };
 
   if (query == "lund") {
-    return fileReader("animals_lund.json");
+    items = fileReader("animals_lund.json");
+    total = items.length;
+
+    result = { total: total, items: items };
   }
 
   if (query == "trygv") {
-    return fileReader("animals_trygv.json");
+    items = fileReader("animals_trygv.json");
+    total = items.length;
+
+    result = { total: total, items: items };
   }
 
   return result;

--- a/src/functions/database.mock.js
+++ b/src/functions/database.mock.js
@@ -16,22 +16,14 @@ export const getAnimal = (id) => {
 };
 
 export const getAnimals = (query) => {
-  let total = 0;
-  let items = [];
-  let result = { total: total, items: items };
+  const result = { total: 0, items: [] };
 
   if (query == "lund") {
-    items = fileReader("animals_lund.json");
-    total = items.length;
-
-    result = { total: total, items: items };
+    return fileReader("animals_lund.json");
   }
 
   if (query == "trygv") {
-    items = fileReader("animals_trygv.json");
-    total = items.length;
-
-    result = { total: total, items: items };
+    return fileReader("animals_trygv.json");
   }
 
   return result;
@@ -42,15 +34,10 @@ export const getCompany = (id) => {
 };
 
 export const getCompanies = (query) => {
-  let total = 0;
-  let items = [];
-  let result = { total: total, items: items };
+  const result = { total: 0, items: [] };
 
   if (query == "lund") {
-    items = fileReader("animals_lund.json");
-    total = items.length;
-
-    result = { total: total, items: items };
+    return fileReader("companies_lund.json");
   }
   return result;
 };

--- a/src/functions/database.mock.js
+++ b/src/functions/database.mock.js
@@ -42,7 +42,17 @@ export const getCompany = (id) => {
 };
 
 export const getCompanies = (query) => {
-  return query == "lund" ? fileReader("companies_lund.json") : [];
+  let total = 0;
+  let items = [];
+  let result = { total: total, items: items };
+
+  if (query == "lund") {
+    items = fileReader("animals_lund.json");
+    total = items.length;
+
+    result = { total: total, items: items };
+  }
+  return result;
 };
 
 export const getFarms = () => {

--- a/src/functions/farmsFetcher.js
+++ b/src/functions/farmsFetcher.js
@@ -46,7 +46,7 @@ export default class FarmsFetcher {
     const total = result.hits.total.value <= this.maxTotal ? result.hits.total.value : this.maxTotal;
 
     if (total === 0) {
-      resolve([]);
+      resolve({ total: 0, items: [] });
       return;
     }
 
@@ -66,7 +66,7 @@ export default class FarmsFetcher {
       return;
     }
 
-    resolve(this.data); // Callback
+    resolve({ total: total, items: this.data }); // Callback
   }
 
   fetch() {


### PR DESCRIPTION
These endpoints now return totals as part of result

- `/api/animals/search` - with string in body
- `/api/companies/search` - with string in body
- `/api/companies/` - return all farms


Before returned only a list of items

`[]`

Now return object with a total and the list of items 

`{total: 0, items: []}`