### PR TITLE
feat: Locations API returns total in result

### DIFF
--- a/src/app/api/locations/search/route.test.js
+++ b/src/app/api/locations/search/route.test.js
@@ -26,7 +26,7 @@ describe("POST /api/locations/search", () => {
   });
 
   test(`POST /api/locations/search { query: "lund" } should return at least 1 item`, async () => {
-    const actual = data.length;
+    const actual = data.total;
     const expected = 1;
 
     assert.isAtLeast(actual, expected, `Number of items returned: ${actual} - should return at least ${expected}`);

--- a/src/data/locations_lund.json
+++ b/src/data/locations_lund.json
@@ -1,13 +1,16 @@
-[
-  {
-    "id": 209,
-    "location": {
-      "google": {
-        "administrative_area_level_1": "Rogaland",
-        "administrative_area_level_2": "Lund"
-      }
-    },
-    "name": "The Happy Alpaca Farm in Lund",
-    "location.google.administrative_area_level_2": ["<em>Lund</em>"]
-  }
-]
+{
+  "total": 1,
+  "items": [
+    {
+      "id": 209,
+      "location": {
+        "google": {
+          "administrative_area_level_1": "Rogaland",
+          "administrative_area_level_2": "Lund"
+        }
+      },
+      "name": "The Happy Alpaca Farm in Lund",
+      "location.google.administrative_area_level_2": ["<em>Lund</em>"]
+    }
+  ]
+}

--- a/src/functions/database.mock.js
+++ b/src/functions/database.mock.js
@@ -34,12 +34,7 @@ export const getCompany = (id) => {
 };
 
 export const getCompanies = (query) => {
-  const result = { total: 0, items: [] };
-
-  if (query == "lund") {
-    return fileReader("companies_lund.json");
-  }
-  return result;
+  return query == "lund" ? fileReader("companies_lund.json") : { total: 0, items: [] };
 };
 
 export const getFarms = () => {
@@ -55,5 +50,5 @@ export const getGeoDistanceRadius = (lat, lng, radius, publicFarms, privateFarms
 };
 
 export const getLocations = (query) => {
-  return query == "lund" ? fileReader("locations_lund.json") : [];
+  return query == "lund" ? fileReader("locations_lund.json") : { total: 0, items: [] };
 };

--- a/src/functions/locationsFetcher.js
+++ b/src/functions/locationsFetcher.js
@@ -73,7 +73,7 @@ export default class LocationsFetcher {
     const total = result.hits.total.value <= this.maxTotal ? result.hits.total.value : this.maxTotal;
 
     if (total === 0) {
-      resolve([]);
+      resolve({ total: 0, items: [] });
       return;
     }
 
@@ -95,7 +95,7 @@ export default class LocationsFetcher {
       return;
     }
 
-    resolve(this.data); // Callback
+    resolve({ total: total, items: this.data }); // Callback
   }
 
   fetch() {


### PR DESCRIPTION
Now return totals as part of result

- `/api/locations/search` - with string in body


Before returned only a list of items

`[]`

Now return object with a total and the list of items 

`{total: 0, items: []}`