### PR TITLE
feat: API `from`, `size` params for pagination - api/animals, api/locations, api/companies

### DIFF
--- a/src/app/api/animals/search/route.js
+++ b/src/app/api/animals/search/route.js
@@ -4,7 +4,13 @@ export async function POST(request) {
   try {
     const formData = await request.formData();
     const query = formData.get("query");
-    const result = await db.getAnimals(query);
+
+    const url = new URL(request?.url);
+    const searchParams = new URLSearchParams(url?.searchParams);
+    const from = searchParams.get("from");
+    const size = searchParams.get("size");
+
+    const result = await db.getAnimals(query, from, size);
 
     return Response.json(result, { status: 200 });
   } catch (error) {

--- a/src/app/api/animals/search/route.test.js
+++ b/src/app/api/animals/search/route.test.js
@@ -32,21 +32,35 @@ describe(`POST /api/animals/search { query: "trygv" }`, () => {
     assert.isAtLeast(actual, expected, `Number of items returned: ${actual} - should return at least ${expected}`);
   });
 
-  test(`Value of data[0].alpacaId`, async () => {
+  test(`Value of param: from`, async () => {
+    const actual = data.from;
+    const expected = 0;
+
+    assert.equal(actual, expected, `Param: ${actual} - should return ${expected}`);
+  });
+
+  test(`Value of param: size`, async () => {
+    const actual = data.size;
+    const expected = 100;
+
+    assert.equal(actual, expected, `Param: ${actual} - should return ${expected}`);
+  });
+
+  test(`Value of alpacaId`, async () => {
     const actual = data.items[0].alpacaId;
     const expected = 2773;
 
     assert.equal(actual, expected, `Item ${actual} - should return ${expected}`);
   });
 
-  test(`Value of  data[0].alpacaRegisteredName[0]`, async () => {
+  test(`Value of alpacaRegisteredName`, async () => {
     const actual = data.items[0].alpacaRegisteredName[0];
     const expected = "ALPAKKAHAGEN SØRUMS <em>TRYGVE</em>";
 
     assert.equal(actual, expected, `Item ${actual} - should return ${expected}`);
   });
 
-  test(`Value of  data[0].alpacaShortName[0]`, async () => {
+  test(`Value of alpacaShortName`, async () => {
     const actual = data.items[0].alpacaShortName[0];
     const expected = "<em>TRYGVE</em>";
 

--- a/src/app/api/companies/search/route.js
+++ b/src/app/api/companies/search/route.js
@@ -4,7 +4,13 @@ export async function POST(request) {
   try {
     const formData = await request.formData();
     const query = formData.get("query");
-    const result = await db.getCompanies(query);
+
+    const url = new URL(request?.url);
+    const searchParams = new URLSearchParams(url?.searchParams);
+    const from = searchParams.get("from");
+    const size = searchParams.get("size");
+
+    const result = await db.getCompanies(query, from, size);
 
     return Response.json(result, { status: 200 });
   } catch (error) {

--- a/src/app/api/companies/search/route.test.js
+++ b/src/app/api/companies/search/route.test.js
@@ -32,14 +32,28 @@ describe(`POST /api/companies/search { query: "lund" }`, () => {
     assert.isAtLeast(actual, expected, `Number of items returned: ${actual} - should return at least ${expected}`);
   });
 
-  test(`Value of id[0]`, async () => {
+  test(`Value of param: from`, async () => {
+    const actual = data.from;
+    const expected = 0;
+
+    assert.equal(actual, expected, `Param: ${actual} - should return ${expected}`);
+  });
+
+  test(`Value of param: size`, async () => {
+    const actual = data.size;
+    const expected = 100;
+
+    assert.equal(actual, expected, `Param: ${actual} - should return ${expected}`);
+  });
+
+  test(`Value of id`, async () => {
     const actual = data.items[0].id;
     const expected = 197;
 
     assert.equal(actual, expected, `Item ${actual} - should return ${expected}`);
   });
 
-  test(`Value of name[0]`, async () => {
+  test(`Value of name`, async () => {
     const actual = data.items[0].name;
     const expected = `Margit <em>Lund</em>-Mikkelson`;
 

--- a/src/app/api/locations/search/route.js
+++ b/src/app/api/locations/search/route.js
@@ -4,7 +4,13 @@ export async function POST(request) {
   try {
     const formData = await request.formData();
     const query = formData.get("query");
-    const result = await db.getLocations(query);
+
+    const url = new URL(request?.url);
+    const searchParams = new URLSearchParams(url?.searchParams);
+    const from = searchParams.get("from");
+    const size = searchParams.get("size");
+
+    const result = await db.getLocations(query, from, size);
 
     return Response.json(result, { status: 200 });
   } catch (error) {

--- a/src/app/api/locations/search/route.test.js
+++ b/src/app/api/locations/search/route.test.js
@@ -31,4 +31,18 @@ describe("POST /api/locations/search", () => {
 
     assert.isAtLeast(actual, expected, `Number of items returned: ${actual} - should return at least ${expected}`);
   });
+
+  test(`Value of param: from`, async () => {
+    const actual = data.from;
+    const expected = 0;
+
+    assert.equal(actual, expected, `Param: ${actual} - should return ${expected}`);
+  });
+
+  test(`Value of param: size`, async () => {
+    const actual = data.size;
+    const expected = 100;
+
+    assert.equal(actual, expected, `Param: ${actual} - should return ${expected}`);
+  });
 });

--- a/src/data/animals_lund.json
+++ b/src/data/animals_lund.json
@@ -37,5 +37,7 @@
       "alpacaShortName": ["LA <em>LUNA</em>"],
       "companyId": 40
     }
-  ]
+  ],
+  "from": "0",
+  "size": "100"
 }

--- a/src/data/animals_trygv.json
+++ b/src/data/animals_trygv.json
@@ -13,5 +13,7 @@
       "alpacaShortName": ["<em>TRYGVE</em>"],
       "companyId": 28
     }
-  ]
+  ],
+  "from": "0",
+  "size": "100"
 }

--- a/src/data/companies_lund.json
+++ b/src/data/companies_lund.json
@@ -21,5 +21,7 @@
       "id": 142,
       "name": ["Kjell Harald <em>Lunde</em>"]
     }
-  ]
+  ],
+  "from": "0",
+  "size": "100"
 }

--- a/src/data/locations_lund.json
+++ b/src/data/locations_lund.json
@@ -6,11 +6,12 @@
       "location": {
         "google": {
           "administrative_area_level_1": "Rogaland",
-          "administrative_area_level_2": "Lund"
+          "administrative_area_level_2": ["<em>Lund</em>"]
         }
       },
-      "name": "Kamperhaug v/Victoria Rasmussen og Gard Syver",
-      "location.google.administrative_area_level_2": ["<em>Lund</em>"]
+      "name": "Kamperhaug v/Victoria Rasmussen og Gard Syver"
     }
-  ]
+  ],
+  "from": "0",
+  "size": "100"
 }

--- a/src/functions/animalsFetcher.js
+++ b/src/functions/animalsFetcher.js
@@ -1,13 +1,10 @@
 export default class AnimalsFetcher {
-  constructor(elastic, query = "") {
+  constructor(elastic, query = "", from, size) {
     this.elastic = elastic;
     this.data = []; // Initial stated
-
     this.query = query;
-    this.from = 0;
-    this.size = 100;
-    this.continue = true;
-    this.maxTotal = 10000;
+    this.from = from ?? 0;
+    this.size = size ?? 100;
   }
 
   async _fetch(resolve, reject) {
@@ -54,10 +51,10 @@ export default class AnimalsFetcher {
       reject(error);
     }
 
-    const total = result.hits.total.value <= this.maxTotal ? result.hits.total.value : this.maxTotal;
+    const total = result.hits.total.value;
 
     if (total === 0) {
-      resolve({ total: 0, items: [] });
+      resolve({ total: 0, items: [], from: this.from, size: this.size });
       return;
     }
 
@@ -70,16 +67,7 @@ export default class AnimalsFetcher {
       this.data.push(animal);
     });
 
-    this.from = this.from + this.size;
-
-    this.continue = this.from <= total;
-
-    if (this.continue) {
-      await this._fetch(resolve); // Callback
-      return;
-    }
-
-    resolve({ total: total, items: this.data }); // Callback
+    resolve({ total: total, items: this.data, from: this.from, size: this.size }); // Callback
   }
 
   fetch() {

--- a/src/functions/companiesFetcher.js
+++ b/src/functions/companiesFetcher.js
@@ -1,13 +1,10 @@
 export default class CompaniesFetcher {
-  constructor(elastic, query = "") {
+  constructor(elastic, query = "", from, size) {
     this.elastic = elastic;
     this.data = []; // Initial stated
-
     this.query = query;
-    this.from = 0;
-    this.size = 25;
-    this.continue = true;
-    this.maxTotal = 999;
+    this.from = from ?? 0;
+    this.size = size ?? 100;
   }
 
   async _fetch(resolve, reject) {
@@ -49,10 +46,10 @@ export default class CompaniesFetcher {
       reject(error);
     }
 
-    const total = result.hits.total.value <= this.maxTotal ? result.hits.total.value : this.maxTotal;
+    const total = result.hits.total.value;
 
     if (total === 0) {
-      resolve({ total: 0, items: [] });
+      resolve({ total: 0, items: [], from: this.from, size: this.size });
       return;
     }
 
@@ -65,16 +62,7 @@ export default class CompaniesFetcher {
       this.data.push(farm);
     });
 
-    this.from = this.from + this.size;
-
-    this.continue = this.from <= total;
-
-    if (this.continue) {
-      await this._fetch(resolve); // Callback
-      return;
-    }
-
-    resolve({ total: total, items: this.data }); // Callback
+    resolve({ total: total, items: this.data, from: this.from, size: this.size }); // Callback
   }
 
   fetch() {

--- a/src/functions/database.elastic.js
+++ b/src/functions/database.elastic.js
@@ -43,9 +43,9 @@ export const getCompany = cache(async (id) => {
   return await fetcher.fetch();
 });
 
-export const getCompanies = cache(async (query) => {
+export const getCompanies = cache(async (query, from, size) => {
   const db = connectToDatabase();
-  const fetcher = new CompaniesFetcher(db, query);
+  const fetcher = new CompaniesFetcher(db, query, from, size);
 
   return await fetcher.fetch();
 });

--- a/src/functions/database.elastic.js
+++ b/src/functions/database.elastic.js
@@ -57,9 +57,9 @@ export const getFarms = cache(async () => {
   return await fetcher.fetch();
 });
 
-export const getLocations = cache(async (query) => {
+export const getLocations = cache(async (query, from, size) => {
   const db = connectToDatabase();
-  const fetcher = new LocationsFetcher(db, query);
+  const fetcher = new LocationsFetcher(db, query, from, size);
 
   return await fetcher.fetch();
 });

--- a/src/functions/database.elastic.js
+++ b/src/functions/database.elastic.js
@@ -30,9 +30,12 @@ export const getAnimal = cache(async (id) => {
   return await fetcher.fetch();
 });
 
-export const getAnimals = cache(async (query) => {
+export const getAnimals = cache(async (query, from, size) => {
   const db = connectToDatabase();
-  const fetcher = new AnimalsFetcher(db, query);
+
+  console.log("db - from", from);
+  console.log("db - size", size);
+  const fetcher = new AnimalsFetcher(db, query, from, size);
 
   return await fetcher.fetch();
 });

--- a/src/functions/database.elastic.js
+++ b/src/functions/database.elastic.js
@@ -32,9 +32,6 @@ export const getAnimal = cache(async (id) => {
 
 export const getAnimals = cache(async (query, from, size) => {
   const db = connectToDatabase();
-
-  console.log("db - from", from);
-  console.log("db - size", size);
   const fetcher = new AnimalsFetcher(db, query, from, size);
 
   return await fetcher.fetch();


### PR DESCRIPTION
These APIs always use `from`, `size` params with defaults. No more fetch all until max reached. Return `from`, `size` params in response.

- POST `/api/animals/search?from=0&size=100`
- POST `/api/locations/search?from=0&size=100`
- POST `/api/companies/search?from=0&size=100`
